### PR TITLE
Catch exception in CustomDevice finalizer

### DIFF
--- a/source/Client/SoundDevice.cs
+++ b/source/Client/SoundDevice.cs
@@ -226,7 +226,14 @@ namespace TeamSpeak.Sdk.Client
         /// </summary>
         ~CustomDevice()
         {
-            Dispose(false);
+            try
+            {
+                Dispose(false);
+            }
+            catch (Exception)
+            {
+                // Don't allow exceptions to escape the finalizer, which would crash the process.
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
We were getting unhandled exceptions on application shudown/recycling with a "device still in use" message. Finalizers are called in unpredictable order, so we were unable to guarantee that the device was cleaned up properly (Connection disposed) before the finalizer was called. Exceptions should not escape finalizer logic.